### PR TITLE
Added "Sum" to the Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
  - [Math](#math)   
     - [min](#min)
     - [max](#max)
+    - [sum](#sum)
     - [percentage](#percentage)
     - [ceil](#ceil)
     - [floor](#floor)


### PR DESCRIPTION
A link to the "Sum" example was missing from the Table of Contents. I have added it in.