### PR TITLE
Removing special characters

### DIFF
--- a/src/app/pipes/string/slugify.ts
+++ b/src/app/pipes/string/slugify.ts
@@ -6,7 +6,9 @@ export class SlugifyPipe implements PipeTransform {
 
   transform(str: string): string {
     return GeneralHelper.isString(str)
-      ? str.toLowerCase().replace(/\s+/g, '-')
+      ? str.toLowerCase()
+      .replace(/[^a-z0-9 -]/g, ' ')
+      .replace(/\s+/g, '-')
       : str;
   }
 }

--- a/src/app/pipes/string/slugify.ts
+++ b/src/app/pipes/string/slugify.ts
@@ -7,7 +7,7 @@ export class SlugifyPipe implements PipeTransform {
   transform(str: string): string {
     return GeneralHelper.isString(str)
       ? str.toLowerCase()
-      .replace(/[^a-z0-9 -]/g, ' ')
+      .replace(/[^a-z0-9-]/g, ' ')
       .replace(/\s+/g, '-')
       : str;
   }


### PR DESCRIPTION
The present state of the slugify function does escape or remove special characters.
For instance , it can't slugify a url {{"https://github.com/danrevah" | slugify}} and will cause problems in angular2 routes.
So add the regex to remove special characters output : https-github.com-danrevah