### PR TITLE
Make groupBy pure again

### DIFF
--- a/src/app/pipes/array/group-by.ts
+++ b/src/app/pipes/array/group-by.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import {extractDeepPropertyByMapKey, isFunction} from '../helpers/helpers';
 
-@Pipe({name: 'groupBy', pure: false})
+@Pipe({name: 'groupBy'})
 export class GroupByPipe implements PipeTransform {
 
   transform(input: any, discriminator: any = [], delimiter: string = '|'): any {


### PR DESCRIPTION
impure pipes could be dangerous to user experience if one doesn't know exactly how they work