### PR TITLE
Enhancement/ Unique filter array based on object property

### DIFF
--- a/src/app/pipes/array/unique.spec.ts
+++ b/src/app/pipes/array/unique.spec.ts
@@ -22,4 +22,10 @@ describe('DiffPipe', () => {
     expect(pipe.transform([1, 2, 3, 1, 2, 3])).toEqual([1, 2, 3]);
     expect(pipe.transform([1, 2, 5, 1, 3, 7, 8, 5, 10])).toEqual([1,2,5,3,7,8,10]);
   });
+
+  it('should filter the array based on object properties when a property name is supplied in arguments',()=>{
+  	expect(pipe.transform([{a:1,b:true},{a:1,b:true},{a:3,b:false}],'b')).toEqual([{a:1,b:true},{a:3,b:false}]);
+  	expect(pipe.transform([15,12,{a:1,b:true},{a:3,b:false}],'b')).toEqual([{a:1,b:true},{a:3,b:false}]);
+  	expect(pipe.transform([15,12,{a:1,b:true},{a:3,b:false}],'c')).toEqual([]);    
+  })
 });

--- a/src/app/pipes/array/unique.spec.ts
+++ b/src/app/pipes/array/unique.spec.ts
@@ -25,7 +25,14 @@ describe('DiffPipe', () => {
 
   it('should filter the array based on object properties when a property name is supplied in arguments',()=>{
   	expect(pipe.transform([{a:1,b:true},{a:1,b:true},{a:3,b:false}],'b')).toEqual([{a:1,b:true},{a:3,b:false}]);
-  	expect(pipe.transform([15,12,{a:1,b:true},{a:3,b:false}],'b')).toEqual([{a:1,b:true},{a:3,b:false}]);
-  	expect(pipe.transform([15,12,{a:1,b:true},{a:3,b:false}],'c')).toEqual([]);    
+  	expect(pipe.transform([1,2,{a:1,b:true},{a:3,b:false}],'b')).toEqual([{a:1,b:true},{a:3,b:false}]);
+  	expect(pipe.transform([1,2,{a:1,b:true},{a:3,b:false}],'c')).toEqual([]);    
+  })
+  
+  it('should filter the array based on object deep properties when a property name dot separated is supplied in arguments',()=>{
+  	expect(pipe.transform([{b:{c:{d:true}}},{b:{c:{d:false}}},{b:{c:{d:true}}}],'b.c.d')).toEqual([{b:{c:{d:true}}},{b:{c:{d:false}}}]);
+    expect(pipe.transform([1,2,{b:{c:{d:true}}},{b:{c:{d:false}}}],'b.c.d')).toEqual([{b:{c:{d:true}}},{b:{c:{d:false}}}]);
+  	expect(pipe.transform([{b:{c:{d:true}}},{b:{c:{d:false}}}],'b.c')).toEqual([{b:{c:{d:true}}},{b:{c:{d:false}}}]);
+  	expect(pipe.transform([{b:{c:{d:true}}},{b:{c:{d:false}}}],'b.c.e')).toEqual([]);
   })
 });

--- a/src/app/pipes/array/unique.ts
+++ b/src/app/pipes/array/unique.ts
@@ -1,4 +1,5 @@
 import { PipeTransform, Pipe } from '@angular/core';
+import { isUndefined, isObject, extractDeepPropertyByMapKey } from  '../helpers/helpers';
 
 @Pipe({ name: 'unique' })
 export class UniquePipe implements PipeTransform {
@@ -6,13 +7,17 @@ export class UniquePipe implements PipeTransform {
   transform(input: any, propertyName?: string): any[] {
     const uniques: boolean[] = [];
     return Array.isArray(input) ?
-      typeof propertyName === 'undefined' ?
+      isUndefined(propertyName) ?
         input.filter((e, i) => input.indexOf(e) === i) :
         input.filter((e, i) => {
-          if (typeof e !== 'object' || !e.hasOwnProperty(propertyName) || uniques[e[propertyName]]) {
+          let value = extractDeepPropertyByMapKey(e,propertyName);
+          value = isObject(value)? JSON.stringify(value):value;
+
+          if (isUndefined(value) || uniques[value]) {
             return false;
           }
-          uniques[e[propertyName]] = true;
+
+          uniques[value] = true;
           return true;
         }) : input;
   }

--- a/src/app/pipes/array/unique.ts
+++ b/src/app/pipes/array/unique.ts
@@ -1,11 +1,19 @@
-import {PipeTransform, Pipe} from '@angular/core';
+import { PipeTransform, Pipe } from '@angular/core';
 
-@Pipe({name: 'unique'})
+@Pipe({ name: 'unique' })
 export class UniquePipe implements PipeTransform {
 
-  transform(input: any): any[] {
-    return Array.isArray(input)
-      ? input.filter((e, i) => input.indexOf(e) === i)
-      : input;
+  transform(input: any, propertyName?: string): any[] {
+    const uniques: boolean[] = [];
+    return Array.isArray(input) ?
+      typeof propertyName === 'undefined' ?
+        input.filter((e, i) => input.indexOf(e) === i) :
+        input.filter((e, i) => {
+          if (typeof e !== 'object' || !e.hasOwnProperty(propertyName) || uniques[e[propertyName]]) {
+            return false;
+          }
+          uniques[e[propertyName]] = true;
+          return true;
+        }) : input;
   }
 }


### PR DESCRIPTION
Addresses #55 , #51 
example usage
```typescript
items = [
    {name: 'sample', weight: 102},
    {name: 'example', weight: 56},
    {name: 'example', weight: 28}
]
```
template
```html
<span *ngFor="let item of items | unique: 'name'">{{ item.weight }}</span>
```

this output two spans with the text 102, 56 respectively.

if the array contains non-objects and a property name is used, non-objects and objects that doesn't have the property will be excluded from the result, this is by default since we want elements unique in that property only.