### PR TITLE
Build the package completely in separate folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 /tmp
 coverage/
 #bundles/
-#esm/
+esm/
+aot/
 
 # dependencies
 /node_modules

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,10 +6,10 @@ const plugins = [
   nodeResolve({ jsnext: true,  module: true,  extensions: ['.js'] })
 ];
 
-let dest = 'bundles/bundle.umd.js';
+let dest = 'esm/bundles/bundle.umd.js';
 
 if (process.env.BUNDLE_MIN === 'true') {
-  dest = 'bundles/bundle.umd.min.js';
+  dest = 'esm/bundles/bundle.umd.min.js';
   plugins.push(
     uglify()
   );

--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -11,6 +11,7 @@
     "noUnusedLocals": true,
     "suppressImplicitAnyIndexErrors": false,
     "declaration": true,
+    "outDir": "aot",
     "lib": ["es6", "dom"],
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
At this time you publish all sources, so there are some problems, for example, with build on angular 5. I suggest to build the project completely in separate directory (in this PR it's esm directory). After build you should publish only esm folder. Also it seems, aot build is useless