### PR TITLE
Fix lint warnings

### DIFF
--- a/src/pipes/array/index.ts
+++ b/src/pipes/array/index.ts
@@ -27,7 +27,7 @@ const ARRAY_PIPES = [
   TrurthifyPipe, UnionPipe, UniquePipe, WithoutPipe, PluckPipe, ShufflePipe,
   EveryPipe, SomePipe, SamplePipe, GroupByPipe, GroupByImpurePipe,
   FilterByPipe, FilterByImpurePipe, OrderByPipe, OrderByImpurePipe,
-  RangePipe
+  RangePipe,
 ];
 
 @NgModule({

--- a/src/pipes/array/range.spec.ts
+++ b/src/pipes/array/range.spec.ts
@@ -16,18 +16,18 @@ describe('RangePipe', () => {
     expect(pipe.transform(0, 0)).toEqual([]);
   });
 
-  it('should returns a new array with the length of the second argument', () => {
-    expect(pipe.transform(0, 0)).length == 0;
-    expect(pipe.transform(0, 1000)).length == 1000;
-    expect(pipe.transform(1, 5)).length == 5;
+  it('should return a new array with the length of the second argument', () => {
+    expect(pipe.transform(0, 0).length).toEqual(0);
+    expect(pipe.transform(0, 1000).length).toEqual(1000);
+    expect(pipe.transform(1, 5).length).toEqual(5);
 
-    expect(pipe.transform(0, 0, 0)).length == 0;
-    expect(pipe.transform(0, 0, 2)).length == 0;
-    expect(pipe.transform(1, 5, 0)).length == 5;
-    expect(pipe.transform(1, 5, 2)).length == 5;
+    expect(pipe.transform(0, 0, 0).length).toEqual(0);
+    expect(pipe.transform(0, 0, 2).length).toEqual(0);
+    expect(pipe.transform(1, 5, 0).length).toEqual(5);
+    expect(pipe.transform(1, 5, 2).length).toEqual(5);
   });
 
-  it('should returns a new array filled', () => {
+  it('should return a new array filled', () => {
     expect(pipe.transform(0, 5)).toEqual([0, 1, 2, 3, 4]);
     expect(pipe.transform(1, 5)).toEqual([1, 2, 3, 4, 5]);
 
@@ -37,7 +37,7 @@ describe('RangePipe', () => {
     expect(pipe.transform(2, 5, 2)).toEqual([2, 4, 6, 8, 10]);
   });
 
-  it('should returns a new array filled with only negatives', () => {
+  it('should return a new array filled with only negatives', () => {
     expect(pipe.transform(0, 5, -1)).toEqual([0, -1, -2, -3, -4]);
     expect(pipe.transform(-1, 5, -2)).toEqual([-1, -3, -5, -7, -9]);
     expect(pipe.transform(-2, 5, -2)).toEqual([-2, -4, -6, -8, -10]);


### PR DESCRIPTION
These commits fix warnings found by running `npm run lint` (`ng lint --type-check`).