### PR TITLE
allow to set splitter for ucwords as an arg

### DIFF
--- a/src/pipes/string/ucwords.spec.ts
+++ b/src/pipes/string/ucwords.spec.ts
@@ -17,6 +17,11 @@ describe("UcFirstPipe Tests", () => {
     expect(result).toEqual("Foo Bar Baz");
   });
 
+  it("Should capitalize all words joined by -", () => {
+    const result = pipe.transform("foo-bar-baz", "-");
+    expect(result).toEqual("Foo-Bar-Baz");
+  });
+
   it("Should test mixed strings capitalize behaviour", () => {
     const result = pipe.transform("foo bar baz $a $b $c some string to test");
     expect(result).toEqual("Foo Bar Baz $a $b $c Some String To Test");

--- a/src/pipes/string/ucwords.ts
+++ b/src/pipes/string/ucwords.ts
@@ -3,15 +3,15 @@ import { isString } from "../helpers/helpers";
 
 @Pipe({ name: "ucwords" })
 export class UcWordsPipe implements PipeTransform {
-  transform(input: string): string;
-  transform(input: any): any;
+  transform(input: string, splitter?: string): string;
+  transform(input: any, splitter?: string): any;
 
-  transform(text: any): string {
+  transform(text: any, splitter = " "): string {
     if (isString(text)) {
       return text
-        .split(" ")
+        .split(splitter)
         .map((sub: any) => sub.slice(0, 1).toUpperCase() + sub.slice(1))
-        .join(" ");
+        .join(splitter);
     }
 
     return text;


### PR DESCRIPTION
useful when you have to eg capitalize http header `x-forwarded-proto` -> `X-Forwarded-Proto` 
