### PR TITLE
Added make-plural-string pipe and isVowel() in helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
     - [match](#match)
     - [lpad](#lpad)
     - [rpad](#rpad)
+    - [make-plural-string](#make-plural-string)
     - [wrap](#wrap)
  - [Array](#Array)   
     - [diff](#diff)
@@ -361,6 +362,21 @@ Right pad a string to a given length using a given pad character  (default is a 
 ```html
 <p>{{'Foo' | rpad: 5: '#'}}</p> <!-- Output: "Foo##" -->
 ```
+
+### make-plural-string
+
+Make a singular string plural. Optional `quantity` argument specifies how many of the singular string there are.
+
+**Usage:** `string | make-plural-string: [quantity:string|optional]`
+
+```html
+<span>{{'Painting' | make-plural-string}}</span> <!-- Output: "Paintings" -->
+<span>{{'Painting' | make-plural-string: 1}}</span> <!-- Output: "Painting" -->
+<span>{{'One Painting' | make-plural-string: 1}}</span> <!-- Output: "One Painting" -->
+<span>{{'Painting' | make-plural-string: 4}}</span> <!-- Output: "Paintings" -->
+<span>{{'Four Painting' | make-plural-string: 4}}</span> <!-- Output: "Four Paintings" -->
+``` 
+
 
 ### wrap
 

--- a/src/pipes/helpers/helpers.ts
+++ b/src/pipes/helpers/helpers.ts
@@ -26,6 +26,12 @@ export function isNumberFinite(value: any) {
   return isNumber(value) && isFinite(value);
 }
 
+export function isVowel(letter: string): boolean {
+  const vowels = ["a", "e", "i", "o", "u"];
+
+  return vowels.indexOf(letter) !== -1;
+}
+
 export function applyPrecision(num: number, precision: number) {
   if (precision <= 0) {
     return Math.round(num);

--- a/src/pipes/string/index.ts
+++ b/src/pipes/string/index.ts
@@ -17,6 +17,7 @@ import { MatchPipe } from "./match";
 import { TestPipe } from "./test";
 import { LeftPadPipe } from "./lpad";
 import { RightPadPipe } from "./rpad";
+import { MakePluralStringPipe } from "./pluralize";
 import { WrapPipe } from "./wrap";
 
 export const STRING_PIPES = [
@@ -38,6 +39,7 @@ export const STRING_PIPES = [
   TestPipe,
   LeftPadPipe,
   RightPadPipe,
+  MakePluralStringPipe,
   WrapPipe,
 ];
 
@@ -66,4 +68,5 @@ export { MatchPipe } from "./match";
 export { TestPipe } from "./test";
 export { LeftPadPipe } from "./lpad";
 export { RightPadPipe } from "./rpad";
+export { MakePluralStringPipe } from "./pluralize";
 export { WrapPipe } from "./wrap";

--- a/src/pipes/string/pluralize.spec.ts
+++ b/src/pipes/string/pluralize.spec.ts
@@ -1,0 +1,126 @@
+import { MakePluralStringPipe } from "./pluralize";
+
+describe("MakePluralStringPipe Tests", () => {
+  let pipe: MakePluralStringPipe;
+
+  beforeEach(() => {
+    pipe = new MakePluralStringPipe();
+  });
+
+  describe("Misc. Inputs", () => {
+    it('should return "" if passed null', () => {
+      expect(pipe.transform(null)).toEqual("" as string);
+    });
+
+    it('should return "" if passed undefined', () => {
+      expect(pipe.transform(undefined)).toEqual("" as string);
+    });
+
+    it('should return "" if passed ""', () => {
+      expect(pipe.transform("")).toEqual("" as string);
+    });
+  });
+
+  describe("Naive Transformations of One Word", () => {
+    it("should return a plural when naively-transforming a singular entity", () => {
+      expect(pipe.transform("Flippy-Floop")).toEqual("Flippy-Floops" as string);
+    });
+
+    it('should return a plural when naively-transforming a singular entity that ends in "y"', () => {
+      expect(pipe.transform("Flippy-Flappy")).toEqual("Flippy-Flappies" as string);
+    });
+
+    it('should return a plural when naively-transforming a singular entity that ends in "s"', () => {
+      expect(pipe.transform("Lens")).toEqual("Lenses" as string);
+    });
+
+    it("should return a singular entity when naively-transforming an explicitly-singular entity", () => {
+      expect(pipe.transform("Flippy-Flappy", 1)).toEqual("Flippy-Flappy" as string);
+    });
+  });
+
+  describe("Naive Transformations of Two-Word Entities", () => {
+    it("should return a plural when naively-transforming a two-word singular entity", () => {
+      expect(pipe.transform("Flippy Floop")).toEqual("Flippy Floops" as string);
+    });
+
+    it('should return a plural when naively-transforming a two-word singular entity that ends in "s"', () => {
+      expect(pipe.transform("Lost Lens")).toEqual("Lost Lenses" as string);
+    });
+    it('should return a plural when naively-transforming a two-word singular entity that ends in "y"', () => {
+      expect(pipe.transform("Flippy Flappy")).toEqual("Flippy Flappies" as string);
+    });
+
+    it("should return a singular entity when naively-transforming a two-word explicitly-singular entity", () => {
+      expect(pipe.transform("Flippy Flappy", 1)).toEqual("Flippy Flappy" as string);
+    });
+  });
+
+  describe('Using English-language rules for words ending in "y"', () => {
+    it('should return "days" if passed "day"', () => {
+      expect(pipe.transform("day")).toEqual("days" as string);
+    });
+
+    it('should return "day" if passed "day" and 1', () => {
+      expect(pipe.transform("day", 1)).toEqual("day" as string);
+    });
+
+    it('should return "days" if passed "day" and 99', () => {
+      expect(pipe.transform("day", 99)).toEqual("days" as string);
+    });
+
+    it('should return "Days" if passed "Day" and 99', () => {
+      expect(pipe.transform("Day", 99)).toEqual("Days" as string);
+    });
+
+    it('should return "monasteries" if passed "monastery"', () => {
+      expect(pipe.transform("monastery")).toEqual("monasteries" as string);
+    });
+
+    it('should return "monastery" if passed "monastery" and 1', () => {
+      expect(pipe.transform("monastery", 1)).toEqual("monastery" as string);
+    });
+
+    it('should return "monasteries" if passed "monastery" and 99', () => {
+      expect(pipe.transform("monastery", 99)).toEqual("monasteries" as string);
+    });
+
+    it('should return "spies" if passed "spy"', () => {
+      expect(pipe.transform("spy")).toEqual("spies" as string);
+    });
+
+    it('should return "spy" if passed "spy" and 1', () => {
+      expect(pipe.transform("spy", 1)).toEqual("spy" as string);
+    });
+
+    it('should return "spies" if passed "spy" and 99', () => {
+      expect(pipe.transform("spy", 99)).toEqual("spies" as string);
+    });
+  });
+
+  describe("Using Known Irregular Words", () => {
+    it('should return "Octopodes" if passed "Octopus"', () => {
+      expect(pipe.transform("Octopus")).toEqual("Octopodes");
+    });
+
+    it('should return "octopodes" if passed "octopus"', () => {
+      expect(pipe.transform("octopus")).toEqual("octopodes");
+    });
+
+    it('should return "Octopus" if passed "Octopus" and 1', () => {
+      expect(pipe.transform("Octopus", 1)).toEqual("Octopus");
+    });
+
+    it('should return "octopus" if passed "octopus" and 1', () => {
+      expect(pipe.transform("octopus", 1)).toEqual("octopus");
+    });
+
+    it('should return "One Octopus" if passed "One Octopus" and 1', () => {
+      expect(pipe.transform("One Octopus", 1)).toEqual("One Octopus");
+    });
+
+    it('should return "Four Octopodes" if passed "Four Octopus" and 4', () => {
+      expect(pipe.transform("Four Octopus", 4)).toEqual("Four Octopodes");
+    });
+  });
+});

--- a/src/pipes/string/pluralize.ts
+++ b/src/pipes/string/pluralize.ts
@@ -1,0 +1,199 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { isVowel } from "../helpers/helpers";
+
+@Pipe({
+  name: "make-plural-string",
+})
+
+/**
+ * Takes a singular entity string and pluralizes it.
+ * Uses both naive and holdout-list approaches.
+ * If several words appear in the string, only the last word is pluralized -- this
+ * means that if "your story" was passed in, "your stories" would be passed out.
+ * @constructor
+ * @param {string} singularEntity - Entity to pluralize. Pass as a singular ('story' or 'house').
+ *          NOTE: The last word is examined. So you can pass in e.g. 'my story'.
+ * @param {number} [quantity=0] quantity - How many of the entity are there? If left blank, this will
+ *          pluralize the string (e.g. 'story' -> 'stories', 'house' -> 'houses'). If given a value,
+ *          this will pluralize appropriately (e.g. ('story', 1) -> 'story', ('story', 2) -> 'stories').
+ */
+export class MakePluralStringPipe implements PipeTransform {
+  private irregularMap: any = {
+    addendum: "addenda",
+    alga: "algae",
+    alumna: "alumnae",
+    alumnus: "alumni",
+    analysis: "analyses",
+    antenna: "antennae",
+    appendix: "appendices",
+    aquarium: "aquaria",
+    arch: "arches",
+    axe: "axes",
+    axis: "axes",
+    bacillus: "bacilli",
+    bacterium: "bacteria",
+    basis: "bases",
+    batch: "batches",
+    beach: "beaches",
+    beau: "beaux",
+    bison: "bison",
+    brush: "brushes",
+    buffalo: "buffaloes",
+    bureau: "bureaus",
+    bus: "busses",
+    cactus: "cacti",
+    calf: "calves",
+    chateau: "chateaux",
+    cherry: "cherries",
+    child: "children",
+    church: "churches",
+    circus: "circuses",
+    cod: "cod",
+    corps: "corps",
+    corpus: "corpora",
+    crisis: "crises",
+    criterion: "criteria",
+    curriculum: "curricula",
+    datum: "data",
+    deer: "deer",
+    diagnosis: "diagnoses",
+    die: "dice",
+    domino: "dominoes",
+    dwarf: "dwarves",
+    echo: "echoes",
+    elf: "elves",
+    ellipsis: "ellipses",
+    embargo: "embargoes",
+    emphasis: "emphases",
+    erratum: "errata",
+    fax: "faxes",
+    fireman: "firemen",
+    fish: "fish",
+    flush: "flushes",
+    focus: "foci",
+    foot: "feet",
+    formula: "formulas",
+    fungus: "fungi",
+    genus: "genera",
+    goose: "geese",
+    grafito: "grafiti",
+    half: "halves",
+    hero: "heroes",
+    hoax: "hoaxes",
+    hoof: "hooves",
+    hypothesis: "hypotheses",
+    index: "indices",
+    kiss: "kisses",
+    knife: "knives",
+    leaf: "leaves",
+    life: "lives",
+    loaf: "loaves",
+    louse: "lice",
+    man: "men",
+    mango: "mangoes",
+    matrix: "matrices",
+    means: "means",
+    medium: "media",
+    memorandum: "memoranda",
+    millennium: "milennia",
+    moose: "moose",
+    mosquito: "mosquitoes",
+    motto: "mottoes",
+    mouse: "mice",
+    nebula: "nebulae",
+    neurosis: "neuroses",
+    nucleus: "nuclei",
+    oasis: "oases",
+    octopus: "octopodes",
+    ovum: "ova",
+    ox: "oxen",
+    paralysis: "paralyses",
+    parenthesis: "parentheses",
+    person: "people",
+    phenomenon: "phenomena",
+    plateau: "plateaux",
+    potato: "potatoes",
+    quiz: "quizzes",
+    radius: "radii",
+    reflex: "reflexes",
+    "runner-up": "runners-up",
+    scampo: "scampi",
+    scarf: "scarves",
+    scissors: "scissors",
+    scratch: "scratches",
+    self: "selves",
+    series: "series",
+    sheaf: "sheaves",
+    sheep: "sheep",
+    shelf: "shelves",
+    "son-in-law": "sons-in-law",
+    species: "species",
+    splash: "splashes",
+    stimulus: "stimuli",
+    stitch: "stitches",
+    stratum: "strata",
+    syllabus: "syllabi",
+    symposium: "symposia",
+    synopsis: "synopses",
+    synthesis: "syntheses",
+    tableau: "tableaux",
+    tax: "taxes",
+    that: "those",
+    thesis: "theses",
+    thief: "thieves",
+    this: "these",
+    tomato: "tomatoes",
+    tooth: "teeth",
+    tornado: "tornadoes",
+    torpedo: "torpedoes",
+    vertebra: "vertebrae",
+    veto: "vetoes",
+    vita: "vitae",
+    volcano: "volcanoes",
+    waltz: "waltzes",
+    wash: "washes",
+    watch: "watches",
+    wharf: "wharves",
+    wife: "wives",
+    wolf: "wolves",
+    woman: "women",
+    zero: "zeroes",
+  };
+
+  transform(singularEntity: string, quantity: number = 0): string {
+    if (!singularEntity || singularEntity === "") {
+      return "";
+    }
+
+    if (quantity === 1) {
+      return singularEntity;
+    } else {
+      const lastWord = singularEntity.trim().split(" ")[singularEntity.trim().split(" ").length - 1];
+      if (this.irregularMap[lastWord.toLocaleLowerCase()]) {
+        if (lastWord[0] === lastWord[0].toLocaleUpperCase()) {
+          return singularEntity.replace(
+            lastWord,
+            this.irregularMap[lastWord.toLocaleLowerCase()].replace(
+              this.irregularMap[lastWord.toLocaleLowerCase()][0],
+              this.irregularMap[lastWord.toLocaleLowerCase()][0].toLocaleUpperCase()
+            )
+          );
+        }
+
+        return singularEntity.replace(lastWord, this.irregularMap[lastWord.toLocaleLowerCase()]);
+      } else if (lastWord[lastWord.length - 1] === "y") {
+        // Naive approach:
+        // consonant+y = word - 'y' +'ies'
+        // vowel+y = word + 's'
+
+        return isVowel(lastWord[lastWord.length - 2])
+          ? singularEntity + "s"
+          : singularEntity.replace(lastWord, lastWord.slice(0, -1) + "ies");
+      } else if (lastWord[lastWord.length - 1] === "s") {
+        return singularEntity + "es";
+      } else {
+        return singularEntity + "s";
+      }
+    }
+  }
+}


### PR DESCRIPTION
This solves a pretty typical problem when you're trying to be intelligent about displaying something like a datatable. Rather than one-offing this every time, you can pass your single entity name (e.g "Picture") and a record count (e.g. "filteredPictures") and get correctly-pluralized output.