### PR TITLE
uc first word and lc rest for title support

### DIFF
--- a/src/pipes/string/ucfirstlcrest.spec.ts
+++ b/src/pipes/string/ucfirstlcrest.spec.ts
@@ -1,0 +1,29 @@
+import { UcFirstLcRestPipe } from './ucfirstlcrest';
+
+describe('UcFirstLcRestPipe Tests', () => {
+  let pipe: UcFirstLcRestPipe;
+
+  beforeEach(() => {
+    pipe = new UcFirstLcRestPipe();
+  });
+
+  it('Should return value if not a string', () => {
+    expect(pipe.transform(23)).toEqual(23);
+    expect(pipe.transform(true)).toEqual(true);
+  });
+
+  it('Should capitalize the first word and lowercase the rest', () => {
+    const result = pipe.transform('foo Bar bAs baZ');
+    expect(result).toEqual('Foo bar bas baz');
+  });
+
+  it('Should test mixed strings capitalize behaviour', () => {
+    const result = pipe.transform('foo Bar bAs baZ &f $2 jUst A random STriNg FOR testinG');
+    expect(result).toEqual('Foo bar bas baz &f $2 just a random string for testing');
+  });
+
+  it('Should test special names', () => {
+    expect(pipe.transform('linked-in')).toEqual('Linked-in');
+    expect(pipe.transform(`mcdonald's`)).toEqual(`Mcdonald's`);
+  });
+});

--- a/src/pipes/string/ucfirstlcrest.ts
+++ b/src/pipes/string/ucfirstlcrest.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isString } from '../helpers/helpers';
+
+@Pipe({ name: 'ucFirstLcRest' })
+export class UcFirstLcRestPipe implements PipeTransform {
+  transform(input: string): string;
+  transform(input: any): any;
+
+  transform(text: any): any {
+    
+    if (isString(text)) {
+      return text[0].toUpperCase() + 
+      text.substring(1, text.length).toLowerCase();
+    }
+
+    return text;
+  }
+}


### PR DESCRIPTION
**Description of the pipe**

I needed a pipe that capitalizes the first word in a title and lowercase the rest of the title words for my website articles. 

ucfirst uppercase the first word in a string such as a title. ucwords uppercase every word in a string. I built and tested a pipe that capitalizes the first word in a string and lowercases the rest of the words. 

**Use case**

Some bloggers like to capitalize only the first word in an article title, including myself. It's simple and tested. 

Please let me know if you have any concerns.