### PR TITLE
Added timeRemaining pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
  - [Changelog](CHANGELOG.md)
  - [Date](#date)   
     - [timeAgo](#timeago)
+    - [timeRemaining](#timeremaining)
  - [String](#string)
     - [aOrAn](#aoran)
     - [repeat](#repeat)
@@ -187,6 +188,18 @@ const lastWeek = moment().subtract(10, 'days');
 ```html
 <span>Updated: {{now | timeAgo}}</span> <!-- Output: "just now" -->
 <span>Updated: {{lastWeek | timeAgo}}</span> <!-- Output: "last week" -->
+```
+
+### timeRemaining
+
+Time remaining pipe converts numeric seconds between 0 and 86399 (1 second less than 1 day in seconds) to a string in format HH:mm:ss
+
+**Usage:** `number | timeRemaining`
+
+```html
+<span>Time Remaining: {{0 | timeRemaining}}</span> <!-- Output: "00:00:00" -->
+<span>Time Remaining: {{90 | timeRemaining}}</span> <!-- Output: "00:01:30" -->
+<span>Time Remaining: {{86399 | timeRemaining}}</span> <!-- Output: "23:59:59" -->
 ```
 
 ## String

--- a/src/pipes/date/index.ts
+++ b/src/pipes/date/index.ts
@@ -1,7 +1,8 @@
 import { NgModule } from '@angular/core';
 import { TimeAgoPipe } from './time-ago';
+import { TimeRemainingPipe } from './time-remaining';
 
-export const DATE_PIPES = [TimeAgoPipe];
+export const DATE_PIPES = [TimeAgoPipe, TimeRemainingPipe];
 
 @NgModule({
   declarations: DATE_PIPES,
@@ -11,3 +12,4 @@ export const DATE_PIPES = [TimeAgoPipe];
 export class NgDatePipesModule {}
 
 export { TimeAgoPipe } from './time-ago';
+export { TimeRemainingPipe } from './time-remaining';

--- a/src/pipes/date/time-remaining.spec.ts
+++ b/src/pipes/date/time-remaining.spec.ts
@@ -1,0 +1,28 @@
+import { TimeRemainingPipe } from './time-remaining';
+
+describe('TimeRemainingPipe', () => {
+  let pipe: TimeRemainingPipe;
+
+  beforeEach(() => {
+    pipe = new TimeRemainingPipe();
+  });
+
+  it('should not change anything if value is not a number between 0 and 86399', () => {
+    expect(pipe.transform(-1)).toEqual(-1);
+    expect(pipe.transform(86400)).toEqual(86400);
+    expect(pipe.transform('foobar')).toEqual('foobar');
+    expect(pipe.transform([])).toEqual([]);
+    expect(pipe.transform(true)).toEqual(true);
+    expect(pipe.transform(false)).toEqual(false);
+    expect(pipe.transform(NaN)).toEqual(NaN);
+    expect(pipe.transform(null)).toEqual(null);
+    expect(pipe.transform(undefined)).toEqual(undefined);
+  });
+
+  it('should return a string in format HH:mm:ss', () => {
+    expect(pipe.transform(0)).toEqual('00:00:00');
+    expect(pipe.transform(90)).toEqual('00:01:30');
+    expect(pipe.transform(3599)).toEqual('00:59:59');
+    expect(pipe.transform(86399)).toEqual('23:59:59');
+  });
+});

--- a/src/pipes/date/time-remaining.ts
+++ b/src/pipes/date/time-remaining.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isNumberFinite } from '../helpers/helpers';
+
+@Pipe({ name: 'timeRemaining' })
+export class TimeRemainingPipe implements PipeTransform {
+  private static DAY_IN_SECONDS = 86400;
+
+  /**
+   * Transform seconds to string in format HH:mm:ss. Returns value as is if not input is not valid.
+   *
+   * @param {any} value - Number of seconds between 0 and 86399 (1 second less than 1 day in seconds)
+   * @returns {any}
+   */
+  transform(value: any) {
+    if (!isNumberFinite(value) || (value < 0 || value >= TimeRemainingPipe.DAY_IN_SECONDS)) {
+      return value;
+    }
+
+    const date = new Date(null);
+    date.setSeconds(value);
+
+    return date.toISOString().substr(11, 8);
+  }
+}


### PR DESCRIPTION
Added new pipe `timeRemaining`. This pipe transforms numeric seconds between `0` and `86399` to a string in format `HH:mm:ss`. This can be useful for displaying countdown timers in a friendly way. While this limited to 24h at most currently, will hopefully look to enhance in the near future to support additional formats and extended time ranges.