### PR TITLE
De-prioritize "any" typed function signatures

### DIFF
--- a/src/ng-pipes/pipes/array/diff.ts
+++ b/src/ng-pipes/pipes/array/diff.ts
@@ -2,8 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'diff' })
 export class DiffPipe implements PipeTransform {
-  transform(input: any[], ...args: any[]): any[];
   transform<T>(input: T, ...args: any[]): T;
+  transform(input: any[], ...args: any[]): any[];
 
   transform(input: any, ...args: any[]): any {
     if (!Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/filter-by.ts
+++ b/src/ng-pipes/pipes/array/filter-by.ts
@@ -11,8 +11,8 @@ import {
 // tslint:disable no-bitwise
 @Pipe({ name: 'filterBy' })
 export class FilterByPipe implements PipeTransform {
-  transform(input: any[], props: Array<string>, search?: any, strict?: boolean): any[];
   transform<T>(input: T, props: Array<string>, search?: any, strict?: boolean): T;
+  transform(input: any[], props: Array<string>, search?: any, strict?: boolean): any[];
   transform(input: any, props: Array<string>, search: any = '', strict: boolean = false): any {
     if (
       !Array.isArray(input) ||

--- a/src/ng-pipes/pipes/array/flatten.ts
+++ b/src/ng-pipes/pipes/array/flatten.ts
@@ -2,8 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'flatten' })
 export class FlattenPipe implements PipeTransform {
-  transform(input: any[], shallow?: boolean): any[];
   transform<T>(input: T, shallow?: boolean): T;
+  transform(input: any[], shallow?: boolean): any[];
 
   transform(input: any, shallow: boolean = false): any {
     if (!Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/intersection.ts
+++ b/src/ng-pipes/pipes/array/intersection.ts
@@ -2,8 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'intersection' })
 export class IntersectionPipe implements PipeTransform {
-  transform(input: any[], ...args: any[]): any[];
   transform<T>(input: T, ...args: any[]): T;
+  transform(input: any[], ...args: any[]): any[];
 
   transform(input: any, ...args: any[]): any {
     if (!Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/order-by.ts
+++ b/src/ng-pipes/pipes/array/order-by.ts
@@ -3,8 +3,8 @@ import { extractDeepPropertyByMapKey, isString, isUndefined } from '../helpers/h
 
 @Pipe({ name: 'orderBy' })
 export class OrderByPipe implements PipeTransform {
-  transform(input: any[], config?: any): any[];
   transform<T>(input: T, config?: any): T;
+  transform(input: any[], config?: any): any[];
 
   transform(input: any, config?: any): any {
     if (!Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/pluck.ts
+++ b/src/ng-pipes/pipes/array/pluck.ts
@@ -3,9 +3,9 @@ import { extractDeepPropertyByMapKey, isObject } from '../helpers/helpers';
 
 @Pipe({ name: 'pluck', pure: false })
 export class PluckPipe implements PipeTransform {
+  transform<T, K extends keyof T>(input: T, map: keyof T): T[K];
   transform(input: any[], map: string): any[];
   transform(input: any, map: string): any;
-  transform<T>(input: T, map: string): T;
 
   transform(input: any, map: string): any {
     if (Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/shuffle.ts
+++ b/src/ng-pipes/pipes/array/shuffle.ts
@@ -2,8 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'shuffle' })
 export class ShufflePipe implements PipeTransform {
-  transform(input: any[]): any[];
   transform<T>(input: T): T;
+  transform(input: any[]): any[];
 
   // Using a version of the Fisher-Yates shuffle algorithm
   // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle

--- a/src/ng-pipes/pipes/array/tail.ts
+++ b/src/ng-pipes/pipes/array/tail.ts
@@ -2,8 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'tail' })
 export class TailPipe implements PipeTransform {
-  transform(input: any[], num?: number): any[];
   transform<T>(input: T, num?: number): T;
+  transform(input: any[], num?: number): any[];
 
   transform(input: any, num: number = 0): any {
     return Array.isArray(input) ? input.slice(num) : input;

--- a/src/ng-pipes/pipes/array/union.ts
+++ b/src/ng-pipes/pipes/array/union.ts
@@ -2,8 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'union' })
 export class UnionPipe implements PipeTransform {
-  transform(input: any[], args?: any[]): any[];
   transform<T>(input: T, args?: any[]): T;
+  transform(input: any[], args?: any[]): any[];
 
   transform(input: any, args: any[] = []): any {
     if (!Array.isArray(input) || !Array.isArray(args)) {


### PR DESCRIPTION
Fixes #185.

I've verified it at least results in the type of `obj` being preserved when doing something like `*ngFor="let obj of arrayOfTypedObjects | orderBy: ...`.

Additionally, I improved the typing of the `pluckBy` pipe.

NOTE: I would appreciate it if this PR could have the "hacktoberfest-accepted" label added :)