### PR TITLE
fix: Handle valid date provided as string #224

### DIFF
--- a/src/ng-pipes/pipes/date/time-ago.ts
+++ b/src/ng-pipes/pipes/date/time-ago.ts
@@ -13,11 +13,11 @@ export class TimeAgoPipe implements PipeTransform {
   ];
 
   /**
-   * @param inputDate: Date | Moment - not included as TypeScript interface,
+   * @param inputDate: Date | Moment | date string - not included as TypeScript interface,
    * in order to keep `ngx-pipes` "pure" from dependencies!
    */
   public transform(inputDate: any): string {
-    if (!inputDate || (!inputDate.getTime && !inputDate.toDate)) {
+    if (!inputDate || (!inputDate.getTime && !inputDate.toDate && !Date.parse(inputDate))) {
       return 'Invalid date';
     }
 


### PR DESCRIPTION
It is common use-case to provide date as a valid string. Even the backend responses come as a plain string which represents the date.