### PR TITLE
fix(stripTags): fix possible ReDoS

### DIFF
--- a/src/ng-pipes/pipes/string/strip-tags.spec.ts
+++ b/src/ng-pipes/pipes/string/strip-tags.spec.ts
@@ -19,4 +19,19 @@ describe('StripTagsPipe Tests', () => {
       '<a href="">foo</a><p class="foo">bar</p>'
     );
   });
+
+  it('Should be fast on big strings', () => {
+    // from https://github.com/danrevah/ngx-pipes/issues/255
+    const string =`• Damas Syrian (100 metres) < 1-minute walk
+• Brazza cocktailbar (160 metres) < 2-minute walk
+• Spanish Inn - Live Music Pub (400 metres) < 5-minute walk
+• Bistro Mathilda (450 metres) < 5-minute walk`;
+
+    const start = performance.now();
+    void pipe.transform(string);
+    const end = performance.now();
+
+    // the old version takes ~4s on an Apple M2 Pro CPU, the new version takes 0.05s
+    expect(end - start).toBeLessThan(1000);
+  });
 });

--- a/src/ng-pipes/pipes/string/strip-tags.ts
+++ b/src/ng-pipes/pipes/string/strip-tags.ts
@@ -5,6 +5,6 @@ export class StripTagsPipe implements PipeTransform {
   transform(text: string, ...allowedTags: any[]): string {
     return allowedTags.length > 0
       ? text.replace(new RegExp(`<(?!\/?(${allowedTags.join('|')})\s*\/?)[^>]+>`, 'g'), '')
-      : text.replace(/<(?:.|\s)*?>/g, '');
+      : text.replace(/<[^>]*>/g, '');
   }
 }


### PR DESCRIPTION
Fix regex performance issues (potentially a ReDoS) in `stripTags` where strings with a single left angle bracket would backtrack indefinitely.

Closes https://github.com/danrevah/ngx-pipes/issues/255