### PR TITLE
feat!: make pipes standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,14 @@
   $ npm install ngx-pipes --save 
   ```
 
-2. You could either add into your module `imports` the `NgPipesModule` in order to add all of the pipes, Or add a specific module such as `NgArrayPipesModule`, `NgObjectPipesModule`, `NgStringPipesModule`, `NgMathPipesModule`, `NgDatePipesModule` or `NgBooleanPipesModule`.
+2. Import any pipes you need to use in your components:
 
   ```typescript
-  import {NgPipesModule} from 'ngx-pipes';
-  
-  @NgModule({
-   // ...
-   imports: [
-     // ...
-     NgPipesModule
-   ]
+  import {ReversePipe} from 'ngx-pipes';
+
+  @Component({
+    imports: [ReversePipe],
+    // ...
   })
   ```
 
@@ -140,6 +137,7 @@
 
   @Component({
     // ..
+    imports: [ReversePipe],
     providers: [ReversePipe]
   })
   export class AppComponent {

--- a/src/ng-pipes/ng-pipes.module.ts
+++ b/src/ng-pipes/ng-pipes.module.ts
@@ -6,6 +6,7 @@ import { NgMathPipesModule } from './pipes/math/index';
 import { NgBooleanPipesModule } from './pipes/boolean/index';
 import { NgDatePipesModule } from './pipes/date/index';
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
   exports: [
     NgArrayPipesModule,

--- a/src/ng-pipes/pipes/array/chunk.ts
+++ b/src/ng-pipes/pipes/array/chunk.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'chunk' })
+@Pipe({
+  name: 'chunk',
+  standalone: true,
+})
 export class ChunkPipe implements PipeTransform {
   transform(input: any, size: number = 1): any {
     if (isString(input)) {

--- a/src/ng-pipes/pipes/array/diff.ts
+++ b/src/ng-pipes/pipes/array/diff.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'diff' })
+@Pipe({
+  name: 'diff',
+  standalone: true,
+})
 export class DiffPipe implements PipeTransform {
   transform<T>(input: T, ...args: any[]): T;
   transform(input: any[], ...args: any[]): any[];

--- a/src/ng-pipes/pipes/array/every.ts
+++ b/src/ng-pipes/pipes/array/every.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'every' })
+@Pipe({
+  name: 'every',
+  standalone: true,
+})
 export class EveryPipe implements PipeTransform {
   transform(input: any, predicate: (value: any, index: number, array: any[]) => boolean): boolean | any[] {
     return Array.isArray(input) ? input.every(predicate) : false;

--- a/src/ng-pipes/pipes/array/filter-by-impure.ts
+++ b/src/ng-pipes/pipes/array/filter-by-impure.ts
@@ -2,5 +2,9 @@ import { Pipe } from '@angular/core';
 import { FilterByPipe } from './filter-by';
 
 // tslint:disable use-pipe-transform-interface
-@Pipe({ name: 'filterByImpure', pure: false })
+@Pipe({
+  name: 'filterByImpure',
+  pure: false,
+  standalone: true,
+})
 export class FilterByImpurePipe extends FilterByPipe {}

--- a/src/ng-pipes/pipes/array/filter-by.ts
+++ b/src/ng-pipes/pipes/array/filter-by.ts
@@ -9,7 +9,10 @@ import {
 } from '../helpers/helpers';
 
 // tslint:disable no-bitwise
-@Pipe({ name: 'filterBy' })
+@Pipe({
+  name: 'filterBy',
+  standalone: true,
+})
 export class FilterByPipe implements PipeTransform {
   transform<T>(input: T, props: Array<string>, search?: any, strict?: boolean): T;
   transform(input: any[], props: Array<string>, search?: any, strict?: boolean): any[];

--- a/src/ng-pipes/pipes/array/flatten.ts
+++ b/src/ng-pipes/pipes/array/flatten.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'flatten' })
+@Pipe({
+  name: 'flatten',
+  standalone: true,
+})
 export class FlattenPipe implements PipeTransform {
   transform<T>(input: T, shallow?: boolean): T;
   transform(input: any[], shallow?: boolean): any[];

--- a/src/ng-pipes/pipes/array/from-pairs.ts
+++ b/src/ng-pipes/pipes/array/from-pairs.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'fromPairs' })
+@Pipe({
+  name: 'fromPairs',
+  standalone: true,
+})
 export class FromPairsPipe implements PipeTransform {
   transform(input: any): any {
     if (!Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/group-by-impure.ts
+++ b/src/ng-pipes/pipes/array/group-by-impure.ts
@@ -2,5 +2,9 @@ import { Pipe } from '@angular/core';
 import { GroupByPipe } from './group-by';
 
 // tslint:disable use-pipe-transform-interface
-@Pipe({ name: 'groupByImpure', pure: false })
+@Pipe({
+  name: 'groupByImpure',
+  pure: false,
+  standalone: true,
+})
 export class GroupByImpurePipe extends GroupByPipe {}

--- a/src/ng-pipes/pipes/array/group-by.ts
+++ b/src/ng-pipes/pipes/array/group-by.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { extractDeepPropertyByMapKey, isFunction } from '../helpers/helpers';
 
-@Pipe({ name: 'groupBy' })
+@Pipe({
+  name: 'groupBy',
+  standalone: true,
+})
 export class GroupByPipe implements PipeTransform {
   transform(input: any, discriminator: any = [], delimiter: string = '|'): any {
     if (!Array.isArray(input)) {

--- a/src/ng-pipes/pipes/array/index.ts
+++ b/src/ng-pipes/pipes/array/index.ts
@@ -51,9 +51,9 @@ const ARRAY_PIPES = [
   FromPairsPipe
 ];
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
-  declarations: ARRAY_PIPES,
-  imports: [],
+  imports: ARRAY_PIPES,
   exports: ARRAY_PIPES,
 })
 export class NgArrayPipesModule {}

--- a/src/ng-pipes/pipes/array/initial.ts
+++ b/src/ng-pipes/pipes/array/initial.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'initial' })
+@Pipe({
+  name: 'initial',
+  standalone: true,
+})
 export class InitialPipe implements PipeTransform {
   transform(input: any[], num: number): any[];
   transform(input: any): any;

--- a/src/ng-pipes/pipes/array/intersection.ts
+++ b/src/ng-pipes/pipes/array/intersection.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'intersection' })
+@Pipe({
+  name: 'intersection',
+  standalone: true,
+})
 export class IntersectionPipe implements PipeTransform {
   transform<T>(input: T, ...args: any[]): T;
   transform(input: any[], ...args: any[]): any[];

--- a/src/ng-pipes/pipes/array/order-by-impure.ts
+++ b/src/ng-pipes/pipes/array/order-by-impure.ts
@@ -2,5 +2,9 @@ import { Pipe } from '@angular/core';
 import { OrderByPipe } from './order-by';
 
 // tslint:disable use-pipe-transform-interface
-@Pipe({ name: 'orderByImpure', pure: false })
+@Pipe({
+  name: 'orderByImpure',
+  pure: false,
+  standalone: true,
+})
 export class OrderByImpurePipe extends OrderByPipe {}

--- a/src/ng-pipes/pipes/array/order-by.ts
+++ b/src/ng-pipes/pipes/array/order-by.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { extractDeepPropertyByMapKey, isString, isUndefined } from '../helpers/helpers';
 
-@Pipe({ name: 'orderBy' })
+@Pipe({
+  name: 'orderBy',
+  standalone: true,
+})
 export class OrderByPipe implements PipeTransform {
   transform<T>(input: T, config?: any): T;
   transform(input: any[], config?: any): any[];

--- a/src/ng-pipes/pipes/array/pluck.ts
+++ b/src/ng-pipes/pipes/array/pluck.ts
@@ -1,7 +1,11 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { extractDeepPropertyByMapKey, isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'pluck', pure: false })
+@Pipe({
+  name: 'pluck',
+  pure: false,
+  standalone: true,
+})
 export class PluckPipe implements PipeTransform {
   transform<T, K extends keyof T>(input: T, map: keyof T): T[K];
   transform(input: any[], map: string): any[];

--- a/src/ng-pipes/pipes/array/range.ts
+++ b/src/ng-pipes/pipes/array/range.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'range' })
+@Pipe({
+  name: 'range',
+  standalone: true,
+})
 export class RangePipe implements PipeTransform {
   transform(start: number = 1, count: number = 0, step: number = 1): any {
     return Array(count)

--- a/src/ng-pipes/pipes/array/reverse.ts
+++ b/src/ng-pipes/pipes/array/reverse.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'reverse' })
+@Pipe({
+  name: 'reverse',
+  standalone: true,
+})
 export class ReversePipe implements PipeTransform {
   transform(input: any): any {
     if (isString(input)) {

--- a/src/ng-pipes/pipes/array/sample.ts
+++ b/src/ng-pipes/pipes/array/sample.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'sample' })
+@Pipe({
+  name: 'sample',
+  standalone: true,
+})
 export class SamplePipe implements PipeTransform {
   transform(input: any[], len?: number): any[];
   transform<T>(input: T, len?: number): T;

--- a/src/ng-pipes/pipes/array/shuffle.ts
+++ b/src/ng-pipes/pipes/array/shuffle.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'shuffle' })
+@Pipe({
+  name: 'shuffle',
+  standalone: true,
+})
 export class ShufflePipe implements PipeTransform {
   transform<T>(input: T): T;
   transform(input: any[]): any[];

--- a/src/ng-pipes/pipes/array/some.ts
+++ b/src/ng-pipes/pipes/array/some.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'some' })
+@Pipe({
+  name: 'some',
+  standalone: true,
+})
 export class SomePipe implements PipeTransform {
   transform(input: any[], predicate: (value: any, index: number, array: any[]) => boolean): boolean;
   transform<T>(input: T, predicate: (value: any, index: number, array: any[]) => boolean): T;

--- a/src/ng-pipes/pipes/array/tail.ts
+++ b/src/ng-pipes/pipes/array/tail.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'tail' })
+@Pipe({
+  name: 'tail',
+  standalone: true,
+})
 export class TailPipe implements PipeTransform {
   transform<T>(input: T, num?: number): T;
   transform(input: any[], num?: number): any[];

--- a/src/ng-pipes/pipes/array/truthify.ts
+++ b/src/ng-pipes/pipes/array/truthify.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'truthify' })
+@Pipe({
+  name: 'truthify',
+  standalone: true,
+})
 export class TrurthifyPipe implements PipeTransform {
   transform(input: any[]): any[];
   transform<T>(input: T): T;

--- a/src/ng-pipes/pipes/array/union.ts
+++ b/src/ng-pipes/pipes/array/union.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'union' })
+@Pipe({
+  name: 'union',
+  standalone: true,
+})
 export class UnionPipe implements PipeTransform {
   transform<T>(input: T, args?: any[]): T;
   transform(input: any[], args?: any[]): any[];

--- a/src/ng-pipes/pipes/array/unique.ts
+++ b/src/ng-pipes/pipes/array/unique.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { extractDeepPropertyByMapKey, isObject, isUndefined } from '../helpers/helpers';
 
-@Pipe({ name: 'unique' })
+@Pipe({
+  name: 'unique',
+  standalone: true,
+})
 export class UniquePipe implements PipeTransform {
   transform(input: any[], args?: string | undefined): any[];
   transform<T>(input: T, args?: string | undefined): T;

--- a/src/ng-pipes/pipes/array/without.ts
+++ b/src/ng-pipes/pipes/array/without.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'without' })
+@Pipe({
+  name: 'without',
+  standalone: true,
+})
 export class WithoutPipe implements PipeTransform {
   transform(input: any[], args?: any[]): any[];
   transform(input: any, args?: any[]): any;

--- a/src/ng-pipes/pipes/boolean/index.ts
+++ b/src/ng-pipes/pipes/boolean/index.ts
@@ -36,9 +36,9 @@ export const BOOLEAN_PIPES = [
   IsLessThanPipe,
 ];
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
-  declarations: BOOLEAN_PIPES,
-  imports: [],
+  imports: BOOLEAN_PIPES,
   exports: BOOLEAN_PIPES,
 })
 export class NgBooleanPipesModule {}

--- a/src/ng-pipes/pipes/boolean/is-array.ts
+++ b/src/ng-pipes/pipes/boolean/is-array.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isArray' })
+@Pipe({
+  name: 'isArray',
+  standalone: true,
+})
 export class IsArrayPipe implements PipeTransform {
   transform(input: any): boolean {
     return Array.isArray(input);

--- a/src/ng-pipes/pipes/boolean/is-defined.ts
+++ b/src/ng-pipes/pipes/boolean/is-defined.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isUndefined } from '../helpers/helpers';
 
-@Pipe({ name: 'isDefined' })
+@Pipe({
+  name: 'isDefined',
+  standalone: true,
+})
 export class IsDefinedPipe implements PipeTransform {
   transform(input: any): boolean {
     return !isUndefined(input);

--- a/src/ng-pipes/pipes/boolean/is-equal-to.ts
+++ b/src/ng-pipes/pipes/boolean/is-equal-to.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isEqualTo' })
+@Pipe({
+  name: 'isEqualTo',
+  standalone: true,
+})
 export class IsEqualToPipe implements PipeTransform {
   transform(input: any, other: any): boolean {
     // tslint:disable-next-line:triple-equals

--- a/src/ng-pipes/pipes/boolean/is-function.ts
+++ b/src/ng-pipes/pipes/boolean/is-function.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isFunction } from '../helpers/helpers';
 
-@Pipe({ name: 'isFunction' })
+@Pipe({
+  name: 'isFunction',
+  standalone: true,
+})
 export class IsFunctionPipe implements PipeTransform {
   transform(input: any): boolean {
     return isFunction(input);

--- a/src/ng-pipes/pipes/boolean/is-greater-equal-than.ts
+++ b/src/ng-pipes/pipes/boolean/is-greater-equal-than.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isGreaterEqualThan' })
+@Pipe({
+  name: 'isGreaterEqualThan',
+  standalone: true,
+})
 export class IsGreaterEqualThanPipe implements PipeTransform {
   transform(input: number, other: number): boolean {
     return input >= other;

--- a/src/ng-pipes/pipes/boolean/is-greater-than.ts
+++ b/src/ng-pipes/pipes/boolean/is-greater-than.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isGreaterThan' })
+@Pipe({
+  name: 'isGreaterThan',
+  standalone: true,
+})
 export class IsGreaterThanPipe implements PipeTransform {
   transform(input: number, other: number): boolean {
     return input > other;

--- a/src/ng-pipes/pipes/boolean/is-identical-to.ts
+++ b/src/ng-pipes/pipes/boolean/is-identical-to.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isIdenticalTo' })
+@Pipe({
+  name: 'isIdenticalTo',
+  standalone: true,
+})
 export class IsIdenticalToPipe implements PipeTransform {
   transform(input: any, other: any): boolean {
     return input === other;

--- a/src/ng-pipes/pipes/boolean/is-less-equal-than.ts
+++ b/src/ng-pipes/pipes/boolean/is-less-equal-than.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isLessEqualThan' })
+@Pipe({
+  name: 'isLessEqualThan',
+  standalone: true,
+})
 export class IsLessEqualThanPipe implements PipeTransform {
   transform(input: number, other: number): boolean {
     return input <= other;

--- a/src/ng-pipes/pipes/boolean/is-less-than.ts
+++ b/src/ng-pipes/pipes/boolean/is-less-than.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isLessThan' })
+@Pipe({
+  name: 'isLessThan',
+  standalone: true,
+})
 export class IsLessThanPipe implements PipeTransform {
   transform(input: number, other: number): boolean {
     return input < other;

--- a/src/ng-pipes/pipes/boolean/is-not-equal-to.ts
+++ b/src/ng-pipes/pipes/boolean/is-not-equal-to.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isNotEqualTo' })
+@Pipe({
+  name: 'isNotEqualTo',
+  standalone: true,
+})
 export class IsNotEqualToPipe implements PipeTransform {
   transform(input: any, other: any): boolean {
     // tslint:disable-next-line:triple-equals

--- a/src/ng-pipes/pipes/boolean/is-not-identical-to.ts
+++ b/src/ng-pipes/pipes/boolean/is-not-identical-to.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isNotIdenticalTo' })
+@Pipe({
+  name: 'isNotIdenticalTo',
+  standalone: true,
+})
 export class IsNotIdenticalToPipe implements PipeTransform {
   transform(input: any, other: any): boolean {
     return input !== other;

--- a/src/ng-pipes/pipes/boolean/is-null.ts
+++ b/src/ng-pipes/pipes/boolean/is-null.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'isNull' })
+@Pipe({
+  name: 'isNull',
+  standalone: true,
+})
 export class IsNullPipe implements PipeTransform {
   transform(input: any): boolean {
     return input === null;

--- a/src/ng-pipes/pipes/boolean/is-number.ts
+++ b/src/ng-pipes/pipes/boolean/is-number.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isNumber } from '../helpers/helpers';
 
-@Pipe({ name: 'isNumber' })
+@Pipe({
+  name: 'isNumber',
+  standalone: true,
+})
 export class IsNumberPipe implements PipeTransform {
   transform(input: any): boolean {
     return isNumber(input);

--- a/src/ng-pipes/pipes/boolean/is-object.ts
+++ b/src/ng-pipes/pipes/boolean/is-object.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'isObject' })
+@Pipe({
+  name: 'isObject',
+  standalone: true,
+})
 export class IsObjectPipe implements PipeTransform {
   transform(input: any): boolean {
     return isObject(input);

--- a/src/ng-pipes/pipes/boolean/is-string.ts
+++ b/src/ng-pipes/pipes/boolean/is-string.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'isString' })
+@Pipe({
+  name: 'isString',
+  standalone: true,
+})
 export class IsStringPipe implements PipeTransform {
   transform(input: any): boolean {
     return isString(input);

--- a/src/ng-pipes/pipes/boolean/is-undefined.ts
+++ b/src/ng-pipes/pipes/boolean/is-undefined.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isUndefined } from '../helpers/helpers';
 
-@Pipe({ name: 'isUndefined' })
+@Pipe({
+  name: 'isUndefined',
+  standalone: true,
+})
 export class IsUndefinedPipe implements PipeTransform {
   transform(input: any): boolean {
     return isUndefined(input);

--- a/src/ng-pipes/pipes/date/index.ts
+++ b/src/ng-pipes/pipes/date/index.ts
@@ -3,9 +3,9 @@ import { TimeAgoPipe } from './time-ago';
 
 export const DATE_PIPES = [TimeAgoPipe];
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
-  declarations: DATE_PIPES,
-  imports: [],
+  imports: DATE_PIPES,
   exports: DATE_PIPES,
 })
 export class NgDatePipesModule {}

--- a/src/ng-pipes/pipes/date/time-ago.ts
+++ b/src/ng-pipes/pipes/date/time-ago.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'timeAgo' })
+@Pipe({
+  name: 'timeAgo',
+  standalone: true,
+})
 export class TimeAgoPipe implements PipeTransform {
   private static YEAR_MS: number = 1000 * 60 * 60 * 24 * 7 * 4 * 12;
   private static MAPPER: any = [

--- a/src/ng-pipes/pipes/math/average.ts
+++ b/src/ng-pipes/pipes/math/average.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isNumberFinite } from '../helpers/helpers';
 
-@Pipe({ name: 'average' })
+@Pipe({
+  name: 'average',
+  standalone: true,
+})
 export class AveragePipe implements PipeTransform {
   transform(arr: number[]): string | number {
     const isValid = arr.every(value => isNumberFinite(value));

--- a/src/ng-pipes/pipes/math/bytes.ts
+++ b/src/ng-pipes/pipes/math/bytes.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { applyPrecision, isNumberFinite, isUndefined } from '../helpers/helpers';
 
-@Pipe({ name: 'bytes' })
+@Pipe({
+  name: 'bytes',
+  standalone: true,
+})
 export class BytesPipe implements PipeTransform {
   private dictionary: Array<{ max: number; type: string }> = [
     { max: 1024, type: 'B' },

--- a/src/ng-pipes/pipes/math/ceil.ts
+++ b/src/ng-pipes/pipes/math/ceil.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'ceil' })
+@Pipe({
+  name: 'ceil',
+  standalone: true,
+})
 export class CeilPipe implements PipeTransform {
   transform(num: number, precision: number = 0): number {
     if (precision <= 0) {

--- a/src/ng-pipes/pipes/math/degrees.ts
+++ b/src/ng-pipes/pipes/math/degrees.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isNumberFinite } from '../helpers/helpers';
 
-@Pipe({ name: 'degrees' })
+@Pipe({
+  name: 'degrees',
+  standalone: true,
+})
 export class DegreesPipe implements PipeTransform {
   transform(radians: number): number {
     if (!isNumberFinite(radians)) {

--- a/src/ng-pipes/pipes/math/floor.ts
+++ b/src/ng-pipes/pipes/math/floor.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'floor' })
+@Pipe({
+  name: 'floor',
+  standalone: true,
+})
 export class FloorPipe implements PipeTransform {
   transform(num: number, precision: number = 0): number {
     if (precision <= 0) {

--- a/src/ng-pipes/pipes/math/index.ts
+++ b/src/ng-pipes/pipes/math/index.ts
@@ -27,9 +27,9 @@ export const MATH_PIPES = [
   RadiansPipe,
 ];
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
-  declarations: MATH_PIPES,
-  imports: [],
+  imports: MATH_PIPES,
   exports: MATH_PIPES,
 })
 export class NgMathPipesModule {}

--- a/src/ng-pipes/pipes/math/max.ts
+++ b/src/ng-pipes/pipes/math/max.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'max' })
+@Pipe({
+  name: 'max',
+  standalone: true,
+})
 export class MaxPipe implements PipeTransform {
   transform(arr: any): number | number[] {
     return Array.isArray(arr) ? Math.max(...arr) : arr;

--- a/src/ng-pipes/pipes/math/min.ts
+++ b/src/ng-pipes/pipes/math/min.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'min' })
+@Pipe({
+  name: 'min',
+  standalone: true,
+})
 export class MinPipe implements PipeTransform {
   transform(arr: any): number | number[] {
     return Array.isArray(arr) ? Math.min(...arr) : arr;

--- a/src/ng-pipes/pipes/math/percentage.ts
+++ b/src/ng-pipes/pipes/math/percentage.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'percentage' })
+@Pipe({
+  name: 'percentage',
+  standalone: true,
+})
 export class PercentagePipe implements PipeTransform {
   transform(num: number, total?: number, floor?: boolean): number;
   transform<T>(num: T, total?: number, floor?: boolean): T;

--- a/src/ng-pipes/pipes/math/pow.ts
+++ b/src/ng-pipes/pipes/math/pow.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'pow' })
+@Pipe({
+  name: 'pow',
+  standalone: true,
+})
 export class PowerPipe implements PipeTransform {
   transform(num: number, power?: number): number;
   transform(num: any, power?: number): any;

--- a/src/ng-pipes/pipes/math/radians.ts
+++ b/src/ng-pipes/pipes/math/radians.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isNumberFinite } from '../helpers/helpers';
 
-@Pipe({ name: 'radians' })
+@Pipe({
+  name: 'radians',
+  standalone: true,
+})
 export class RadiansPipe implements PipeTransform {
   transform(degrees: number): number {
     if (!isNumberFinite(degrees)) {

--- a/src/ng-pipes/pipes/math/round.ts
+++ b/src/ng-pipes/pipes/math/round.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { applyPrecision } from '../helpers/helpers';
 
-@Pipe({ name: 'round' })
+@Pipe({
+  name: 'round',
+  standalone: true,
+})
 export class RoundPipe implements PipeTransform {
   transform(num: number, precision: number = 0): number {
     return applyPrecision(num, precision);

--- a/src/ng-pipes/pipes/math/sqrt.ts
+++ b/src/ng-pipes/pipes/math/sqrt.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'sqrt' })
+@Pipe({
+  name: 'sqrt',
+  standalone: true,
+})
 export class SqrtPipe implements PipeTransform {
   transform(num: number): number;
   transform<T>(num: T): T;

--- a/src/ng-pipes/pipes/math/sum.ts
+++ b/src/ng-pipes/pipes/math/sum.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'sum' })
+@Pipe({
+  name: 'sum',
+  standalone: true,
+})
 export class SumPipe implements PipeTransform {
   transform(num: any[]): number;
   transform<T>(num: any): T;

--- a/src/ng-pipes/pipes/object/diff-obj.ts
+++ b/src/ng-pipes/pipes/object/diff-obj.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { getKeysTwoObjects, isDeepEqual, isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'diffObj' })
+@Pipe({
+  name: 'diffObj',
+  standalone: true,
+})
 export class DiffObjPipe implements PipeTransform {
   transform(obj: any, original: any = {}): any {
     if (Array.isArray(obj) || Array.isArray(original) || !isObject(obj) || !isObject(original)) {

--- a/src/ng-pipes/pipes/object/index.ts
+++ b/src/ng-pipes/pipes/object/index.ts
@@ -10,9 +10,9 @@ import { NgModule } from '@angular/core';
 
 const OBJECT_PIPES = [KeysPipe, ValuesPipe, PairsPipe, PickPipe, InvertPipe, InvertByPipe, OmitPipe, DiffObjPipe];
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
-  declarations: OBJECT_PIPES,
-  imports: [],
+  imports: OBJECT_PIPES,
   exports: OBJECT_PIPES,
 })
 export class NgObjectPipesModule {}

--- a/src/ng-pipes/pipes/object/invert-by.ts
+++ b/src/ng-pipes/pipes/object/invert-by.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'invertBy' })
+@Pipe({
+  name: 'invertBy',
+  standalone: true,
+})
 export class InvertByPipe implements PipeTransform {
   transform(obj: any, cb?: Function): Object {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/object/invert.ts
+++ b/src/ng-pipes/pipes/object/invert.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'invert' })
+@Pipe({
+  name: 'invert',
+  standalone: true,
+})
 export class InvertPipe implements PipeTransform {
   transform(obj: any): Object {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/object/keys.ts
+++ b/src/ng-pipes/pipes/object/keys.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'keys' })
+@Pipe({
+  name: 'keys',
+  standalone: true,
+})
 export class KeysPipe implements PipeTransform {
   transform(obj: any): any[] {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/object/omit.ts
+++ b/src/ng-pipes/pipes/object/omit.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'omit' })
+@Pipe({
+  name: 'omit',
+  standalone: true,
+})
 export class OmitPipe implements PipeTransform {
   transform(obj: any, ...args: Array<string>): Object {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/object/pairs.ts
+++ b/src/ng-pipes/pipes/object/pairs.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'pairs' })
+@Pipe({
+  name: 'pairs',
+  standalone: true,
+})
 export class PairsPipe implements PipeTransform {
   transform(obj: any): any[] {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/object/pick.ts
+++ b/src/ng-pipes/pipes/object/pick.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'pick' })
+@Pipe({
+  name: 'pick',
+  standalone: true,
+})
 export class PickPipe implements PipeTransform {
   transform(obj: any, ...args: Array<string>): Object {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/object/values.ts
+++ b/src/ng-pipes/pipes/object/values.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isObject } from '../helpers/helpers';
 
-@Pipe({ name: 'values' })
+@Pipe({
+  name: 'values',
+  standalone: true,
+})
 export class ValuesPipe implements PipeTransform {
   transform(obj: any): any[] {
     if (Array.isArray(obj) || !isObject(obj)) {

--- a/src/ng-pipes/pipes/string/a-or-an.ts
+++ b/src/ng-pipes/pipes/string/a-or-an.ts
@@ -3,6 +3,7 @@ import { isVowel } from '../helpers/helpers';
 
 @Pipe({
   name: 'aOrAn',
+  standalone: true,
 })
 /**
  * Takes a string and returns the string prepended by 'a' or 'an'.

--- a/src/ng-pipes/pipes/string/camelize.ts
+++ b/src/ng-pipes/pipes/string/camelize.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'camelize' })
+@Pipe({
+  name: 'camelize',
+  standalone: true,
+})
 export class CamelizePipe implements PipeTransform {
   transform(input: string, chars?: string): string;
   transform(input: any, chars?: string): any;

--- a/src/ng-pipes/pipes/string/index.ts
+++ b/src/ng-pipes/pipes/string/index.ts
@@ -45,9 +45,9 @@ export const STRING_PIPES = [
   WrapPipe,
 ];
 
+/** @deprecated Pipes are now standalone; Import them directly. */
 @NgModule({
-  declarations: STRING_PIPES,
-  imports: [],
+  imports: STRING_PIPES,
   exports: STRING_PIPES,
 })
 export class NgStringPipesModule {}

--- a/src/ng-pipes/pipes/string/latinise.ts
+++ b/src/ng-pipes/pipes/string/latinise.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'latinise' })
+@Pipe({
+  name: 'latinise',
+  standalone: true,
+})
 export class LatinisePipe implements PipeTransform {
   // Source: http://semplicewebsites.com/removing-accents-javascript
   // tslint:disable-next-line whitespace max-line-length object-literal-key-quotes

--- a/src/ng-pipes/pipes/string/lines.ts
+++ b/src/ng-pipes/pipes/string/lines.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'lines' })
+@Pipe({
+  name: 'lines',
+  standalone: true,
+})
 export class LinesPipe implements PipeTransform {
   transform(text: any, chars: string = '\\s'): Array<string> | any {
     return isString(text) ? text.replace(/\r\n/g, '\n').split('\n') : text;

--- a/src/ng-pipes/pipes/string/lpad.ts
+++ b/src/ng-pipes/pipes/string/lpad.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'lpad' })
+@Pipe({
+  name: 'lpad',
+  standalone: true,
+})
 export class LeftPadPipe implements PipeTransform {
   transform(str: string, length: number, padCharacter: string = ' '): string {
     if (!isString(str) || str.length >= length) {

--- a/src/ng-pipes/pipes/string/ltrim.ts
+++ b/src/ng-pipes/pipes/string/ltrim.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'ltrim' })
+@Pipe({
+  name: 'ltrim',
+  standalone: true,
+})
 export class LeftTrimPipe implements PipeTransform {
   transform(text: string, chars: string = '\\s'): string {
     return isString(text) ? text.replace(new RegExp(`^[${chars}]+`), '') : text;

--- a/src/ng-pipes/pipes/string/match.ts
+++ b/src/ng-pipes/pipes/string/match.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'match' })
+@Pipe({
+  name: 'match',
+  standalone: true,
+})
 export class MatchPipe implements PipeTransform {
   transform(text: string, pattern: string, flags?: string): RegExpMatchArray | null;
   transform<T>(text: T, pattern: string, flags?: string): T;

--- a/src/ng-pipes/pipes/string/pluralize.ts
+++ b/src/ng-pipes/pipes/string/pluralize.ts
@@ -3,6 +3,7 @@ import { isVowel } from '../helpers/helpers';
 
 @Pipe({
   name: 'makePluralString',
+  standalone: true,
 })
 
 /**

--- a/src/ng-pipes/pipes/string/repeat.ts
+++ b/src/ng-pipes/pipes/string/repeat.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'repeat' })
+@Pipe({
+  name: 'repeat',
+  standalone: true,
+})
 export class RepeatPipe implements PipeTransform {
   transform(str: string, n: number = 1, separator: string = ''): string {
     if (n <= 0) {

--- a/src/ng-pipes/pipes/string/rpad.ts
+++ b/src/ng-pipes/pipes/string/rpad.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'rpad' })
+@Pipe({
+  name: 'rpad',
+  standalone: true,
+})
 export class RightPadPipe implements PipeTransform {
   transform(str: string, length: number = 1, padCharacter: string = ' '): string {
     if (!isString(str) || str.length >= length) {

--- a/src/ng-pipes/pipes/string/rtrim.ts
+++ b/src/ng-pipes/pipes/string/rtrim.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'rtrim' })
+@Pipe({
+  name: 'rtrim',
+  standalone: true,
+})
 export class RightTrimPipe implements PipeTransform {
   transform(text: string, chars: string = '\\s'): string {
     return isString(text) ? text.replace(new RegExp(`[${chars}]+$`), '') : text;

--- a/src/ng-pipes/pipes/string/scan.ts
+++ b/src/ng-pipes/pipes/string/scan.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString, isUndefined } from '../helpers/helpers';
 
-@Pipe({ name: 'scan' })
+@Pipe({
+  name: 'scan',
+  standalone: true,
+})
 export class ScanPipe implements PipeTransform {
   transform(text: string, args: string[] = []): string {
     return isString(text)

--- a/src/ng-pipes/pipes/string/shorten.ts
+++ b/src/ng-pipes/pipes/string/shorten.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'shorten' })
+@Pipe({
+  name: 'shorten',
+  standalone: true,
+})
 export class ShortenPipe implements PipeTransform {
   transform(input: string, length?: number, suffix?: string, wordBreak?: boolean): string;
   transform(input: any, length?: number, suffix?: string, wordBreak?: boolean): any;

--- a/src/ng-pipes/pipes/string/slugify.ts
+++ b/src/ng-pipes/pipes/string/slugify.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'slugify' })
+@Pipe({
+  name: 'slugify',
+  standalone: true,
+})
 export class SlugifyPipe implements PipeTransform {
   transform(str: string): string {
     return isString(str)

--- a/src/ng-pipes/pipes/string/strip-tags.ts
+++ b/src/ng-pipes/pipes/string/strip-tags.ts
@@ -1,6 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'stripTags' })
+@Pipe({
+  name: 'stripTags',
+  standalone: true,
+})
 export class StripTagsPipe implements PipeTransform {
   transform(text: string, ...allowedTags: any[]): string {
     return allowedTags.length > 0

--- a/src/ng-pipes/pipes/string/test.ts
+++ b/src/ng-pipes/pipes/string/test.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'test' })
+@Pipe({
+  name: 'test',
+  standalone: true,
+})
 export class TestPipe implements PipeTransform {
   transform(text: string, pattern: string, flags?: string): boolean;
   transform<T>(text: T, pattern: string, flags?: string): T;

--- a/src/ng-pipes/pipes/string/trim.ts
+++ b/src/ng-pipes/pipes/string/trim.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'trim' })
+@Pipe({
+  name: 'trim',
+  standalone: true,
+})
 export class TrimPipe implements PipeTransform {
   transform(text: string, chars: string = '\\s'): string {
     return isString(text) ? text.replace(new RegExp(`^[${chars}]+|[${chars}]+$`, 'g'), '') : text;

--- a/src/ng-pipes/pipes/string/ucfirst.ts
+++ b/src/ng-pipes/pipes/string/ucfirst.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString, ucFirst } from '../helpers/helpers';
 
-@Pipe({ name: 'ucfirst' })
+@Pipe({
+  name: 'ucfirst',
+  standalone: true,
+})
 export class UcFirstPipe implements PipeTransform {
   transform(input: string): string;
   transform(input: any): any;

--- a/src/ng-pipes/pipes/string/ucwords.ts
+++ b/src/ng-pipes/pipes/string/ucwords.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString, ucFirst } from '../helpers/helpers';
 
-@Pipe({ name: 'ucwords' })
+@Pipe({
+  name: 'ucwords',
+  standalone: true,
+})
 export class UcWordsPipe implements PipeTransform {
   transform(input: string): string;
   transform(input: any): any;

--- a/src/ng-pipes/pipes/string/underscore.ts
+++ b/src/ng-pipes/pipes/string/underscore.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'underscore' })
+@Pipe({
+  name: 'underscore',
+  standalone: true,
+})
 export class UnderscorePipe implements PipeTransform {
   transform(input: string, chars?: string): string;
   transform(input: any, chars?: string): any;

--- a/src/ng-pipes/pipes/string/wrap.ts
+++ b/src/ng-pipes/pipes/string/wrap.ts
@@ -1,7 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isString } from '../helpers/helpers';
 
-@Pipe({ name: 'wrap' })
+@Pipe({
+  name: 'wrap',
+  standalone: true,
+})
 export class WrapPipe implements PipeTransform {
   transform(str: string, prefix: string = '', suffix: string = ''): string {
     if (!isString(str)) {


### PR DESCRIPTION
This PR transforms all pipes to be standalone. The usage of those from their respective modules is still possible, but discouraged. Also updates the README with instructions.

Closes #241

Similar to #252, but also updates README and marks this as a breaking change. Note that the change is most likely not breaking due to the nature of standalone components, but I would recommend releasing this in a major version bump